### PR TITLE
chore: Put glibc and dbus requirements behind build tags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,15 @@ COPY . .
 FROM builder as builder-deps
 
 RUN apt update \
-    && apt install -qy $(cat deb-requirements.txt) \
     && apt install -qy make
 
 FROM builder-deps as builder-build
 
-RUN make build
+RUN CGO_ENABLED=0 make build
 
 FROM python:3.11-slim
 
-RUN apt update && apt install -qy libglib2.0-dev iproute2
+RUN apt update && apt install -qy iproute2
 
 COPY --from=builder-build /nt-connect/nt-connect /usr/bin/nt-connect
 COPY requirements.txt /requirements.txt

--- a/app/daemon_dbus.go
+++ b/app/daemon_dbus.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+//go:build dbus
+// +build dbus
+
+package app
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/northerntechhq/nt-connect/api"
+	apidbus "github.com/northerntechhq/nt-connect/api/dbus"
+	"github.com/northerntechhq/nt-connect/client/dbus"
+)
+
+func getDBUSClient(done <-chan struct{}) (api.Client, error) {
+	dbusAPI, err := dbus.GetDBusAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	//new dbus client
+	apiClient, err := apidbus.NewClient(
+		dbusAPI,
+		apidbus.DBusObjectName,
+		apidbus.DBusObjectPath,
+		apidbus.DBusInterfaceName,
+	)
+	if err != nil {
+		log.Errorf("nt-connect dbus failed to create client, error: %s", err.Error())
+		return nil, err
+	}
+
+	//dbus main loop, requiredaemon.
+	loop := dbusAPI.MainLoopNew()
+	go dbusAPI.MainLoopRun(loop)
+	go func() {
+		<-done
+		dbusAPI.MainLoopQuit(loop)
+	}()
+	return apiClient, nil
+}

--- a/app/daemon_no_dbus.go
+++ b/app/daemon_no_dbus.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Northern.tech AS
+//
+//	Licensed under the Apache License, Version 2.0 (the "License");
+//	you may not use this file except in compliance with the License.
+//	You may obtain a copy of the License at
+//
+//	    http://www.apache.org/licenses/LICENSE-2.0
+//
+//	Unless required by applicable law or agreed to in writing, software
+//	distributed under the License is distributed on an "AS IS" BASIS,
+//	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//	See the License for the specific language governing permissions and
+//	limitations under the License.
+
+//go:build !dbus
+// +build !dbus
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/northerntechhq/nt-connect/api"
+)
+
+func getDBUSClient(<-chan struct{}) (api.Client, error) {
+	return nil, fmt.Errorf("binary not built with dbus support: use 'dbus' build tag to enable")
+}


### PR DESCRIPTION
Dropping these requirements will ease cross platform support (e.g. compiling for OSx "darwin" is now supported out of the box).