### PR TITLE
chore: Updated README after forking mender-connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,15 @@
-[![Build Status](https://gitlab.com/Northern.tech/Mender/mender-connect/badges/master/pipeline.svg)](https://gitlab.com/Northern.tech/Mender/mender-connect/pipelines)
-[![Coverage Status](https://coveralls.io/repos/github/mendersoftware/mender-connect/badge.svg?branch=master)](https://coveralls.io/github/mendersoftware/mender-connect?branch=master)
-[![Go Report Card](https://goreportcard.com/badge/github.com/mendersoftware/mender-connect)](https://goreportcard.com/report/github.com/mendersoftware/mender-connect)
+# nt-connect - Northern.tech connect client
 
-Mender: remote shell access add-on
-==================================
-
-Mender is an open source over-the-air (OTA) software updater for embedded Linux
-devices. Mender comprises a client running at the embedded device, as well as
-a server that manages deployments across many devices.
-
-This repository contains the remote shell access add-on. It enhances the
-[Mender client](https://github.com/mendersoftware/mender), allowing to log in
-to the devices remotely and start a shell in a remote terminal session.
-
-![Mender logo](https://raw.githubusercontent.com/mendersoftware/mender/master/mender_logo.png)
-
-
-## Getting started
-
-To start using Mender, we recommend that you begin with the Getting started
-section in [the Mender documentation](https://docs.mender.io/).
-
-
-## Building from source
-
-## Configuration
-
-## Contributing
-
-We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or
-documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md).
+`nt-connect` is a binary for remote access to devices, allowing retrieval of inventory information, file transfer, and remote terminal sessions.
 
 ## License
 
-Mender is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/mendersoftware/mender-connect/blob/master/LICENSE) for the
-full license text.
+`nt-connect` is licensed under the Apache License, Version 2.0.
+See [LICENSE](https://github.com/NorthernTechHQ/nt-connect/blob/master/LICENSE) for the full license text.
 
 ## Security disclosure
 
-We take security very seriously. If you come across any issue regarding
-security, please disclose the information by sending an email to
-[security@mender.io](security@mender.io). Please do not create a new public
-issue. We thank you in advance for your cooperation.
-
-## Connect with us
-
-* Join the [Mender Hub discussion forum](https://hub.mender.io)
-* Follow us on [Twitter](https://twitter.com/mender_io). Please
-  feel free to tweet us questions.
-* Fork us on [Github](https://github.com/mendersoftware)
-* Create an issue in the [bugtracker](https://northerntech.atlassian.net/projects/MEN)
-* Email us at [contact@mender.io](mailto:contact@mender.io)
-* Connect to the [#mender IRC channel on Libera](https://web.libera.chat/?#mender)
+We take security very seriously.
+If you come across any issue regarding security, please disclose the information by sending an email to [security@northern.tech](security@northern.tech).
+Please do not create a new public issue.
+We thank you in advance for your cooperation.


### PR DESCRIPTION
Removed Mender links to avoid confusion. Reduced it to the minimum
necessary - description, license and security. We can add to this
over time.

Changelog: None
Ticket: ALV-155
