### PR TITLE
ci: Add allow failure for manual build job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,7 @@ build:docker-multiplatform:
     - if: '$CI_COMMIT_REF_NAME =~ /^(main|staging)$/'
       when: always
     - when: manual
+      allow_failure: true
 
 publish:docker-multiplatform:
   rules:


### PR DESCRIPTION
This makes the quite heavy docker build job optional (as intended).