### PR TITLE
fix(shell): Use script command to fix pty errors on Termux

### DIFF
--- a/shell/shell.go
+++ b/shell/shell.go
@@ -61,6 +61,12 @@ func ExecuteShell(uid uint32,
 	cmd.Env = append(cmd.Env, fmt.Sprintf("HOME=%s", homeDir))
 	cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", termString))
 
+	log.Info("using script command to start shell")
+	cmd_wrapper := exec.Command("script", "-qec", shell, "/dev/null")
+	cmd_wrapper.SysProcAttr = cmd.SysProcAttr
+	cmd_wrapper.Dir = cmd.Dir
+	cmd_wrapper.Env = cmd.Env
+	cmd = cmd_wrapper
 	pseudoTTY, err = pty.Start(cmd)
 	if err != nil {
 		return -1, nil, nil, err


### PR DESCRIPTION
The `pty.Start` function was failing in the Termux environment, causing an "input/output error" when trying to read from the pseudo-terminal.

This change wraps the shell command with the `script` utility, which provides a more robust way to create pseudo-terminals across different environments, resolving the issue on Termux.