### PR TITLE
ci: only rebase renovate PRs on conflict and drop the schedule window

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,8 +5,7 @@
 
   "extends": [
     "config:recommended",
-    ":gitSignOff",
-    ":rebaseStalePrs"
+    ":gitSignOff"
   ],
 
   // CODEOWNERS assigns alvaldi-maintainers for everything here.
@@ -17,8 +16,9 @@
   "semanticCommitType": "fix",
   "semanticCommitScope": "deps",
 
-  // Fallback window for weeks with no merges; the renovate CI job is the primary trigger.
-  "schedule": ["after 10pm on Monday", "before 6am on Tuesday"],
+  // Only rebase open PRs when they actually conflict. Rebasing every time the
+  // base branch moves restarts a pipeline for every open PR on each merge.
+  "rebaseWhen": "conflicted",
 
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,


### PR DESCRIPTION
Follow up to #129, which merged before this change went through the other repos

rebaseStalePrs rebased every open renovate PR whenever main moved, so each merge restarted a pipeline for every open renovate PR. rebaseWhen conflicted only rebases when the PR actually conflicts

The schedule window is removed so the GitLab pipeline schedule is the only thing deciding when renovate runs - having both means they can disagree, and when they do renovate does the full lookup and opens nothing

Same change already merged in the mendersoftware repos. Thanks Alf-Rune for catching it on NorthernTechHQ/alvaldi-gui#672 - alvaldi-gui and nt-gui are updated in place, this one needed a follow up since it was already in

Ticket: QA-1485
